### PR TITLE
Fix lag in freeplay menu

### DIFF
--- a/scripts/modules/SEOSFreeplayIconOption.hxc
+++ b/scripts/modules/SEOSFreeplayIconOption.hxc
@@ -13,103 +13,121 @@ import funkin.ui.PixelatedIcon;
 import funkin.ui.freeplay.SongMenuItem;
 import funkin.ui.freeplay.FreeplayState;
 import funkin.PlayerSettings;
+import flixel.util.FlxTimer;
 
 class SEOSFreeplayIconOption extends Module
 {
-    public var save = null;
-    public var char:BaseCharacter;
-    public var iconStyle:String = "kirbiro"; // default to kirbiro
-    public var enabled:Bool = true;
+	public var save = null;
+	public var char:BaseCharacter;
+	public var iconStyle:String = "kirbiro"; // default to kirbiro
+	public var enabled:Bool = true;
+	var garID = ["garcello", "garcellotired", "garcellodead", "garcelloghosty"];
+	var curSelected:Int;
+	function bindSave(){
+		save = new FlxSave();
+		save.bind("freeplayicons", "Greeny3483");
+	}
 
-    function bindSave(){
-        save = new FlxSave();
-        save.bind("freeplayicons", "Greeny3483");
-    }
+	function closeSave(){
+		if(save != null)save.close();
+		save = null;
+	}
 
-    function closeSave(){
-        if(save != null)save.close();
-        save = null;
-    }
+	function new(){
+		super("Freeplay Icons", 1);
+		bindSave();
 
-    function new(){
-        super("Freeplay Icons", 1);
-        bindSave();
+		if(save.data.iconStyle == null)
+			save.data.iconStyle = "kirbiro";
 
-        if(save.data.iconStyle == null)
-            save.data.iconStyle = "kirbiro";
+		iconStyle = save.data.iconStyle;
 
-        iconStyle = save.data.iconStyle;
+		closeSave();
+	}
 
-        closeSave();
-    }
+	public var inOptions:Bool = false;
 
-    public var inOptions:Bool = false;
+	override function onStateChangeEnd(event){
+		super.onStateChangeEnd(event);
+		inOptions = false;
+		if(Std.isOfType(event.targetState, OptionsState)){
+			var prefs = event.targetState.optionsCodex.pages.get("preferences");
+			inOptions = true;
 
-    override function onStateChangeEnd(event){
-        super.onStateChangeEnd(event);
-        inOptions = false;
-        if(Std.isOfType(event.targetState, OptionsState)){
-            var prefs = event.targetState.optionsCodex.pages.get("preferences");
-            inOptions = true;
+			bindSave();
 
-            bindSave();
+			prefs.createPrefItemEnum("Freeplay Icons", "Switches between different alternative freeplay icon sets. \n Applies to: Garcello.", [
+				"kirbiro" => "kirbiro",
+				"AppleHair" => "AppleHair"
+			], function(key:String, value:String) {
+				save.data.iconStyle = value;
+				iconStyle = value;
+			}, save.data.iconStyle);
 
-            prefs.createPrefItemEnum("Freeplay Icons", "Switches between different alternative freeplay icon sets. \n Applies to: Garcello.", [
-                "kirbiro" => "kirbiro",
-                "AppleHair" => "AppleHair"
-            ], function(key:String, value:String) {
-                save.data.iconStyle = value;
-                iconStyle = value;
-            }, save.data.iconStyle);
+		}else if(inOptions)
+			closeSave();
+	}
 
-        }else if(inOptions)
-            closeSave();
-    }
+	override function onSubStateOpenEnd(event) {
+		super.onSubStateOpenEnd(event);
+		if (Std.isOfType(event.targetState, FreeplayState)) {
+			var state = event.targetState;
+			var reset = function () {{ //Needs to be called when DJ does its intro since the game resets the capsule stuff after
+				new FlxTimer().start(0.11, _ -> {
+					curSelected = 0;
+				});
+			}}
+			for (capsule in event.targetState.grpCapsules.members){
+				if (capsule?.freeplayData != null) {
+					if (garID.contains(capsule.freeplayData.songCharacter)){ //Check only Garcello character IDs to prevent lag
+						customDisplay(capsule);
+					}
+				}
+			}
+			if (state.dj != null) {
+      			state.dj.onIntroDone.add(reset);
+			}
+		}
+	}
 
-    function customDisplay(cap:SongMenuItem){
-        /* Original code by @Comedy Lost
-            *  From Doki Doki Takeover Plus! V-Slice Port
-            *  https://gamebanana.com/mods/513366
-            *  ComedyLost- If you want me to remove this, my discord is @greeny3483
-        */
-        if (cap.pixelIcon.animation.curAnim == null || cap.pixelIcon.animation.curAnim.name == 'idle'){
-            if (cap.freeplayData != null){
-                switch (cap.freeplayData.songCharacter){
-                    case 'garcello':
-                        if (iconStyle == "AppleHair"){
-                            cap.pixelIcon.setCharacter('applehairgarcello');
-                        } else {
-                            cap.pixelIcon.setCharacter('garcello');
-                        }
-                    case 'garcellotired':
-                        if (iconStyle == "AppleHair"){
-                            cap.pixelIcon.setCharacter('applehairgarcellotired');
-                        } else {
-                            cap.pixelIcon.setCharacter('garcellotired');
-                        }
-                    case 'garcellodead':
-                        if (iconStyle == "AppleHair"){
-                            cap.pixelIcon.setCharacter('applehairgarcellodead');
-                        } else {
-                            cap.pixelIcon.setCharacter('garcellodead');
-                        }
-                    case 'garcelloghosty':
-                        if (iconStyle == "AppleHair"){
-                            cap.pixelIcon.setCharacter('applehairgarcelloghosty');
-                        } else {
-                            cap.pixelIcon.setCharacter('garcelloghosty');
-                        }
-                }
-            }   
-        }
-    }
-    override function onUpdate(event:UpdateScriptEvent) {
+	function customDisplay(cap:SongMenuItem){
+		if (cap.pixelIcon.animation.curAnim == null || cap.pixelIcon.animation.curAnim.name == 'idle'){
+			if (cap.freeplayData != null && iconStyle == "AppleHair"){
+				switch (cap.freeplayData.songCharacter){
+					case 'garcello':
+						cap.pixelIcon.setCharacter('applehairgarcello');
+					case 'garcellotired':
+						cap.pixelIcon.setCharacter('applehairgarcellotired');
+					case 'garcellodead':
+						cap.pixelIcon.setCharacter('applehairgarcellodead');
+					case 'garcelloghosty':
+						cap.pixelIcon.setCharacter('applehairgarcelloghosty');
+				}
+			}   
+		}
+	}
+	
+	override function onUpdate(event:UpdateScriptEvent) {
 		super.onUpdate(event);
 		if (Std.isOfType(FlxG.state.subState, FreeplayState))
 			{
-				for (capsule in FlxG.state.subState.grpCapsules.members){
-					customDisplay(capsule);
-				}	
+				//All code below is meant to prevent lag in the freeplay menu
+				if (curSelected != FlxG.state.subState.curSelected){
+					curSelected = FlxG.state.subState.curSelected; //Do it only once
+					var curCap = FlxG.state.subState.grpCapsules.members[FlxG.state.subState.curSelected];
+					if (curCap.freeplayData != null && garID.contains(curCap.freeplayData.songCharacter)) customDisplay(curCap);
+				}
+				if (PlayerSettings.player1.controls.UI_LEFT_P || PlayerSettings.player1.controls.UI_RIGHT_P || FlxG.keys.justPressed.Q || FlxG.keys.justPressed.E){
+					new FlxTimer().start(0.1, _ -> {
+						for (capsule in FlxG.state.subState.grpCapsules.members){
+							if (capsule?.freeplayData != null) {
+								if (garID.contains(capsule.freeplayData.songCharacter)){
+									customDisplay(capsule);
+								}
+							}
+						}
+					});
+				}
 			}		
-    }
+	}
 }


### PR DESCRIPTION
Sorry if this is a bit of a mess, this is my first PR on Github. Noticed you added this in a recent update, but it currently lags the freeplay menu a lot since it constantly checks each capsule. 

This PR makes it check only when it needs to (Switching difficulties, changing sorting options, etc.) which should mostly remove the lag

FPS before PR:
![image](https://github.com/user-attachments/assets/f5c4b34f-cf10-4706-8ff4-3bc41ffe1d3b)

FPS after PR:
![image](https://github.com/user-attachments/assets/6d50a9e3-7198-4f11-a372-5f2ac1329d48)
